### PR TITLE
Fix: Rocket combos now explode at drop target instead of source

### DIFF
--- a/src/GameScene.ts
+++ b/src/GameScene.ts
@@ -2024,20 +2024,16 @@ export default class GameScene extends Phaser.Scene {
     }
 
     console.log('🚀🚀 VERTICAL ROCKET + VERTICAL ROCKET COMBO!')
-    console.log(`First rocket (vertical) at [${firstCell.row}, ${firstCell.column}]`)
-    console.log(`Second rocket (will clear row ${secondCell.row}) at [${secondCell.row}, ${secondCell.column}]`)
+    console.log(`Cross explosion at [${firstCell.row}, ${firstCell.column}] (after swap - target location)`)
 
     // Play rocket sound
     this.sound.play('rocket', { volume: 0.4 })
 
-    // Create effects for both rockets
-    const x1 = firstCell.column * CELL_SIZE + CELL_SIZE / 2
-    const y1 = firstCell.row * CELL_SIZE + CELL_SIZE / 2
-    this.createPowerUpEffect(x1, y1, 'vertical-rocket', firstCell)
-
-    const x2 = secondCell.column * CELL_SIZE + CELL_SIZE / 2
-    const y2 = secondCell.row * CELL_SIZE + CELL_SIZE / 2
-    this.createPowerUpEffect(x2, y2, 'horizontal-rocket', secondCell)
+    // Create effects at TARGET location (firstCell is now at target after swap)
+    const x = firstCell.column * CELL_SIZE + CELL_SIZE / 2
+    const y = firstCell.row * CELL_SIZE + CELL_SIZE / 2
+    this.createPowerUpEffect(x, y, 'vertical-rocket', firstCell)
+    this.createPowerUpEffect(x, y, 'horizontal-rocket', firstCell)
 
     // Clear both powerup properties
     firstCell.powerup = null
@@ -2047,9 +2043,10 @@ export default class GameScene extends Phaser.Scene {
     this.markCellForDestructionImmediate(firstCell)
     this.markCellForDestructionImmediate(secondCell)
 
-    // Destroy entire column (from first rocket)
+    // Destroy entire column at TARGET position (firstCell.column after swap)
     for (let row = 0; row < size; row++) {
       const targetCell = this.board[row][firstCell.column]
+      if (!targetCell) continue // Null safety for non-rectangular boards
       if (targetCell.powerup && targetCell !== firstCell && targetCell !== secondCell) {
         console.log(`Chain-activating ${targetCell.powerup} at [${targetCell.row}, ${targetCell.column}]`)
         await this.triggerPowerUp(targetCell)
@@ -2058,9 +2055,10 @@ export default class GameScene extends Phaser.Scene {
       }
     }
 
-    // Destroy entire row (from second rocket)
+    // Destroy entire row at TARGET position (firstCell.row after swap)
     for (let col = 0; col < size; col++) {
-      const targetCell = this.board[secondCell.row][col]
+      const targetCell = this.board[firstCell.row][col]
+      if (!targetCell) continue // Null safety for non-rectangular boards
       if (targetCell.powerup && targetCell !== firstCell && targetCell !== secondCell) {
         console.log(`Chain-activating ${targetCell.powerup} at [${targetCell.row}, ${targetCell.column}]`)
         await this.triggerPowerUp(targetCell)
@@ -2079,20 +2077,16 @@ export default class GameScene extends Phaser.Scene {
     }
 
     console.log('🚀🚀 HORIZONTAL ROCKET + HORIZONTAL ROCKET COMBO!')
-    console.log(`First rocket (horizontal) at [${firstCell.row}, ${firstCell.column}]`)
-    console.log(`Second rocket (will clear column ${secondCell.column}) at [${secondCell.row}, ${secondCell.column}]`)
+    console.log(`Cross explosion at [${firstCell.row}, ${firstCell.column}] (after swap - target location)`)
 
     // Play rocket sound
     this.sound.play('rocket', { volume: 0.4 })
 
-    // Create effects for both rockets
-    const x1 = firstCell.column * CELL_SIZE + CELL_SIZE / 2
-    const y1 = firstCell.row * CELL_SIZE + CELL_SIZE / 2
-    this.createPowerUpEffect(x1, y1, 'horizontal-rocket', firstCell)
-
-    const x2 = secondCell.column * CELL_SIZE + CELL_SIZE / 2
-    const y2 = secondCell.row * CELL_SIZE + CELL_SIZE / 2
-    this.createPowerUpEffect(x2, y2, 'vertical-rocket', secondCell)
+    // Create effects at TARGET location (firstCell is now at target after swap)
+    const x = firstCell.column * CELL_SIZE + CELL_SIZE / 2
+    const y = firstCell.row * CELL_SIZE + CELL_SIZE / 2
+    this.createPowerUpEffect(x, y, 'horizontal-rocket', firstCell)
+    this.createPowerUpEffect(x, y, 'vertical-rocket', firstCell)
 
     // Clear both powerup properties
     firstCell.powerup = null
@@ -2102,9 +2096,10 @@ export default class GameScene extends Phaser.Scene {
     this.markCellForDestructionImmediate(firstCell)
     this.markCellForDestructionImmediate(secondCell)
 
-    // Destroy entire row (from first rocket)
+    // Destroy entire row at TARGET position (firstCell.row after swap)
     for (let col = 0; col < size; col++) {
       const targetCell = this.board[firstCell.row][col]
+      if (!targetCell) continue // Null safety for non-rectangular boards
       if (targetCell.powerup && targetCell !== firstCell && targetCell !== secondCell) {
         console.log(`Chain-activating ${targetCell.powerup} at [${targetCell.row}, ${targetCell.column}]`)
         await this.triggerPowerUp(targetCell)
@@ -2113,9 +2108,10 @@ export default class GameScene extends Phaser.Scene {
       }
     }
 
-    // Destroy entire column (from second rocket)
+    // Destroy entire column at TARGET position (firstCell.column after swap)
     for (let row = 0; row < size; row++) {
-      const targetCell = this.board[row][secondCell.column]
+      const targetCell = this.board[row][firstCell.column]
+      if (!targetCell) continue // Null safety for non-rectangular boards
       if (targetCell.powerup && targetCell !== firstCell && targetCell !== secondCell) {
         console.log(`Chain-activating ${targetCell.powerup} at [${targetCell.row}, ${targetCell.column}]`)
         await this.triggerPowerUp(targetCell)
@@ -2501,12 +2497,18 @@ export default class GameScene extends Phaser.Scene {
         // Left cell
         const leftCol = cell.column - distance
         if (leftCol >= 0) {
-          cellsAtDistance.push(this.board[cell.row][leftCol])
+          const leftCell = this.board[cell.row][leftCol]
+          if (leftCell) { // Null safety for non-rectangular boards
+            cellsAtDistance.push(leftCell)
+          }
         }
         // Right cell
         const rightCol = cell.column + distance
         if (rightCol < size) {
-          cellsAtDistance.push(this.board[cell.row][rightCol])
+          const rightCell = this.board[cell.row][rightCol]
+          if (rightCell) { // Null safety for non-rectangular boards
+            cellsAtDistance.push(rightCell)
+          }
         }
       }
 
@@ -2572,12 +2574,18 @@ export default class GameScene extends Phaser.Scene {
         // Up cell
         const upRow = cell.row - distance
         if (upRow >= 0) {
-          cellsAtDistance.push(this.board[upRow][cell.column])
+          const upCell = this.board[upRow][cell.column]
+          if (upCell) { // Null safety for non-rectangular boards
+            cellsAtDistance.push(upCell)
+          }
         }
         // Down cell
         const downRow = cell.row + distance
         if (downRow < size) {
-          cellsAtDistance.push(this.board[downRow][cell.column])
+          const downCell = this.board[downRow][cell.column]
+          if (downCell) { // Null safety for non-rectangular boards
+            cellsAtDistance.push(downCell)
+          }
         }
       }
 

--- a/tests/powerups.spec.ts
+++ b/tests/powerups.spec.ts
@@ -135,17 +135,25 @@ test('vertical rocket + vertical rocket combo clears column and row', async ({ p
     const firstCell = scene.board[3][4]
     const secondCell = scene.board[4][4]
 
-    // Trigger the combo: first rocket clears column, second clears row
+    // Swap cells first (like drag does)
+    scene.swapCells(firstCell, secondCell)
+
+    // After swap: firstCell is now at [4,4] (target), secondCell is at [3,4]
+    // Combo creates cross explosion at target location [4,4]
     const maybePromise = scene.triggerVerticalRocketCombo(firstCell, secondCell)
     if (maybePromise && typeof maybePromise.then === 'function') {
       await maybePromise
     }
 
-    // collect which cells in column 4 are empty (should all be empty)
-    const columnEmpty = scene.board.map((row: any) => !!row[4].empty)
+    // Process the destruction (combo only marks cells, need to actually destroy them)
+    await scene.destroyCells()
 
-    // collect which cells in row 4 are empty (should all be empty)
+    // Check cells are empty BEFORE refilling (refillBoard will add new gems)
+    const columnEmpty = scene.board.map((row: any) => !!row[4].empty)
     const rowEmpty = scene.board[4].map((c: any) => !!c.empty)
+
+    await scene.makeCellsFall()
+    await scene.refillBoard()
 
     return {
       columnEmpty,
@@ -153,10 +161,10 @@ test('vertical rocket + vertical rocket combo clears column and row', async ({ p
     }
   })
 
-  // expect the entire column 4 to be empty (first vertical rocket)
+  // expect the entire column 4 to be empty (cross explosion at target)
   expect(result.columnEmpty.every(Boolean)).toBeTruthy()
 
-  // expect the entire row 4 to be empty (second rocket triggered as horizontal)
+  // expect the entire row 4 to be empty (cross explosion at target)
   expect(result.rowEmpty.every(Boolean)).toBeTruthy()
 })
 
@@ -192,17 +200,25 @@ test('horizontal rocket + horizontal rocket combo clears row and column', async 
     const firstCell = scene.board[4][3]
     const secondCell = scene.board[4][4]
 
-    // Trigger the combo: first rocket clears row, second clears column
+    // Swap cells first (like drag does)
+    scene.swapCells(firstCell, secondCell)
+
+    // After swap: firstCell is now at [4,4] (target), secondCell is at [4,3]
+    // Combo creates cross explosion at target location [4,4]
     const maybePromise = scene.triggerHorizontalRocketCombo(firstCell, secondCell)
     if (maybePromise && typeof maybePromise.then === 'function') {
       await maybePromise
     }
 
-    // collect which cells in row 4 are empty (should all be empty)
-    const rowEmpty = scene.board[4].map((c: any) => !!c.empty)
+    // Process the destruction (combo only marks cells, need to actually destroy them)
+    await scene.destroyCells()
 
-    // collect which cells in column 4 are empty (should all be empty)
+    // Check cells are empty BEFORE refilling (refillBoard will add new gems)
+    const rowEmpty = scene.board[4].map((c: any) => !!c.empty)
     const columnEmpty = scene.board.map((row: any) => !!row[4].empty)
+
+    await scene.makeCellsFall()
+    await scene.refillBoard()
 
     return {
       rowEmpty,
@@ -210,9 +226,9 @@ test('horizontal rocket + horizontal rocket combo clears row and column', async 
     }
   })
 
-  // expect the entire row 4 to be empty (first horizontal rocket)
+  // expect the entire row 4 to be empty (cross explosion at target)
   expect(result.rowEmpty.every(Boolean)).toBeTruthy()
 
-  // expect the entire column 4 to be empty (second rocket triggered as vertical)
+  // expect the entire column 4 to be empty (cross explosion at target)
   expect(result.columnEmpty.every(Boolean)).toBeTruthy()
 })


### PR DESCRIPTION
## Summary
Fixed rocket combo behavior so cross explosions occur at the drop target location (where the player releases the rocket) instead of the source location (where they started dragging).

## Changes

### GameScene.ts
- **`triggerVerticalRocketCombo()`** (lines 2026-2068)
  - Updated to use `firstCell` for target coordinates after swap
  - Cross explosion now clears both column AND row at drop target
  - Added null safety checks for non-rectangular boards
  
- **`triggerHorizontalRocketCombo()`** (lines 2079-2122)
  - Same pattern as vertical combo
  - Cross explosion at drop target with null safety
  
- **`triggerHorizontalRocketExplosion()`** (lines 2497-2516)
  - Added null safety checks when collecting cells at distance
  - Prevents crashes on octagon/diamond boards
  
- **`triggerVerticalRocketExplosion()`** (lines 2572-2587)
  - Added null safety checks when collecting cells at distance
  - Prevents crashes on octagon/diamond boards

### tests/powerups.spec.ts
- Updated both combo tests to call `swapCells()` before triggering combo (matches actual game flow)
- Added `destroyCells()` call to process destruction after combo
- Check cell emptiness before `refillBoard()` fills them again
- Updated comments to reflect cross explosion behavior

## Test Results
All 4 rocket tests passing:
- ✅ horizontal rocket clears its row when triggered
- ✅ vertical rocket clears its column when triggered  
- ✅ vertical rocket + vertical rocket combo clears column and row
- ✅ horizontal rocket + horizontal rocket combo clears row and column

## Before/After Behavior

**Before:**
- Dragging vertical rocket from [3,4] to [4,4] would explode at [3,4] (source)
- User experience was confusing - explosion didn't match where they dropped

**After:**
- Dragging vertical rocket from [3,4] to [4,4] explodes at [4,4] (target)
- More intuitive - explosion happens where player releases the rocket

## Related Issues
Addresses user feedback: "when dropping one vertical on another vertical the row cleared should be the target row not the source row"

🤖 Generated with [Claude Code](https://claude.com/claude-code)